### PR TITLE
20934 - Add fields to dead letter policy for configuring batch/chunking

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/DeadLetterPolicy.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/DeadLetterPolicy.java
@@ -49,9 +49,33 @@ public class DeadLetterPolicy {
     private String retryLetterTopic;
 
     /**
+     * Enable chunking of messages for retry letter producer.
+     */
+    @Builder.Default
+    private boolean retryLetterChunkingEnabled = false;
+
+    /**
+     * Enable batching of messages for retry letter producer.
+     */
+    @Builder.Default
+    private boolean retryLetterBatchingEnabled = false;
+
+    /**
      * Name of the dead topic where the failing messages will be sent.
      */
     private String deadLetterTopic;
+
+    /**
+     * Enable chunking of messages for dead letter producer.
+     */
+    @Builder.Default
+    private boolean deadLetterChunkingEnabled = false;
+
+    /**
+     * Enable batching of messages for dead letter producer.
+     */
+    @Builder.Default
+    private boolean deadLetterBatchingEnabled = true;
 
     /**
      * Name of the initial subscription name of the dead letter topic.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -612,7 +612,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 if (retryLetterProducer == null) {
                     retryLetterProducer = client.newProducer(Schema.AUTO_PRODUCE_BYTES(schema))
                             .topic(this.deadLetterPolicy.getRetryLetterTopic())
-                            .enableBatching(false)
+                            .enableBatching(this.deadLetterPolicy.isRetryLetterBatchingEnabled())
+                            .enableChunking(this.deadLetterPolicy.isRetryLetterChunkingEnabled())
                             .blockIfQueueFull(false)
                             .create();
                 }
@@ -2093,6 +2094,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                             ((ProducerBuilderImpl<byte[]>) client.newProducer(Schema.AUTO_PRODUCE_BYTES(schema)))
                                     .initialSubscriptionName(this.deadLetterPolicy.getInitialSubscriptionName())
                                     .topic(this.deadLetterPolicy.getDeadLetterTopic())
+                                    .enableBatching(this.deadLetterPolicy.isDeadLetterBatchingEnabled())
+                                    .enableChunking(this.deadLetterPolicy.isDeadLetterChunkingEnabled())
                                     .blockIfQueueFull(false)
                                     .createAsync();
                 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -348,11 +348,19 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             if (StringUtils.isNotBlank(conf.getDeadLetterPolicy().getDeadLetterTopic())) {
                 this.deadLetterPolicy = DeadLetterPolicy.builder()
                         .maxRedeliverCount(conf.getDeadLetterPolicy().getMaxRedeliverCount())
+                        .retryLetterBatchingEnabled(conf.getDeadLetterPolicy().isRetryLetterBatchingEnabled())
+                        .retryLetterChunkingEnabled(conf.getDeadLetterPolicy().isRetryLetterChunkingEnabled())
+                        .deadLetterBatchingEnabled(conf.getDeadLetterPolicy().isDeadLetterBatchingEnabled())
+                        .deadLetterChunkingEnabled(conf.getDeadLetterPolicy().isDeadLetterChunkingEnabled())
                         .deadLetterTopic(conf.getDeadLetterPolicy().getDeadLetterTopic())
                         .build();
             } else {
                 this.deadLetterPolicy = DeadLetterPolicy.builder()
                         .maxRedeliverCount(conf.getDeadLetterPolicy().getMaxRedeliverCount())
+                        .retryLetterBatchingEnabled(conf.getDeadLetterPolicy().isRetryLetterBatchingEnabled())
+                        .retryLetterChunkingEnabled(conf.getDeadLetterPolicy().isRetryLetterChunkingEnabled())
+                        .deadLetterBatchingEnabled(conf.getDeadLetterPolicy().isDeadLetterBatchingEnabled())
+                        .deadLetterChunkingEnabled(conf.getDeadLetterPolicy().isDeadLetterChunkingEnabled())
                         .deadLetterTopic(String.format("%s-%s" + RetryMessageUtil.DLQ_GROUP_TOPIC_SUFFIX,
                                 topic, subscription))
                         .build();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
@@ -363,9 +363,9 @@ public class ConsumerBuilderImplTest {
                 .deadLetterTopic("new-dlq")
                 .maxRedeliverCount(2)
                 .deadLetterBatchingEnabled(false)
-                .deadLetterChunkingEnabled(false)
+                .deadLetterChunkingEnabled(true)
                 .retryLetterBatchingEnabled(true)
-                .retryLetterChunkingEnabled(true)
+                .retryLetterChunkingEnabled(false)
                 .build());
         verify(consumerBuilder.getConf()).setDeadLetterPolicy(notNull());
         DeadLetterPolicy policy = consumerBuilder.getConf().getDeadLetterPolicy();
@@ -374,9 +374,9 @@ public class ConsumerBuilderImplTest {
         assertThat(policy.getDeadLetterTopic()).isEqualTo("new-dlq");
         assertThat(policy.getMaxRedeliverCount()).isEqualTo(2);
         assertFalse(policy.isDeadLetterBatchingEnabled());
-        assertFalse(policy.isDeadLetterChunkingEnabled());
+        assertTrue(policy.isDeadLetterChunkingEnabled());
         assertTrue(policy.isRetryLetterBatchingEnabled());
-        assertTrue(policy.isRetryLetterChunkingEnabled());
+        assertFalse(policy.isRetryLetterChunkingEnabled());
     }
 
     @Test

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
@@ -19,6 +19,9 @@
 package org.apache.pulsar.client.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -347,6 +350,31 @@ public class ConsumerBuilderImplTest {
     }
 
     @Test
+    public void testNonNullDeadLetterPolicy() {
+        PulsarClientImpl client = mock(PulsarClientImpl.class);
+        ConsumerConfigurationData consumerConfigurationData = mock(ConsumerConfigurationData.class);
+        doCallRealMethod().when(consumerConfigurationData).setDeadLetterPolicy(any());
+        when(consumerConfigurationData.getDeadLetterPolicy()).thenCallRealMethod();
+        ConsumerBuilderImpl<byte[]> consumerBuilder = new ConsumerBuilderImpl(client, consumerConfigurationData, Schema.BYTES);
+
+        consumerBuilder.deadLetterPolicy(DeadLetterPolicy.builder()
+                .retryLetterTopic("new-retry")
+                .initialSubscriptionName("new-dlq-sub")
+                .deadLetterTopic("new-dlq")
+                .maxRedeliverCount(2)
+                .deadLetterBatchingEnabled(false)
+                .deadLetterChunkingEnabled(false)
+                .retryLetterBatchingEnabled(true)
+                .retryLetterChunkingEnabled(true)
+                .build());
+        verify(consumerBuilder.getConf()).setDeadLetterPolicy(notNull());
+        assertFalse(consumerBuilder.getConf().getDeadLetterPolicy().isDeadLetterBatchingEnabled());
+        assertFalse(consumerBuilder.getConf().getDeadLetterPolicy().isDeadLetterChunkingEnabled());
+        assertTrue(consumerBuilder.getConf().getDeadLetterPolicy().isRetryLetterBatchingEnabled());
+        assertTrue(consumerBuilder.getConf().getDeadLetterPolicy().isRetryLetterChunkingEnabled());
+    }
+
+    @Test
     public void testConsumerBuilderImplWhenNumericPropertiesAreValid() {
         consumerBuilderImpl.negativeAckRedeliveryDelay(1, TimeUnit.MILLISECONDS);
         consumerBuilderImpl.priorityLevel(1);
@@ -494,6 +522,10 @@ public class ConsumerBuilderImplTest {
         assertEquals(configurationData.getDeadLetterPolicy().getRetryLetterTopic(), "new-retry");
         assertEquals(configurationData.getDeadLetterPolicy().getInitialSubscriptionName(), "new-dlq-sub");
         assertEquals(configurationData.getDeadLetterPolicy().getMaxRedeliverCount(), 2);
+        assertTrue(configurationData.getDeadLetterPolicy().isDeadLetterBatchingEnabled());
+        assertFalse(configurationData.getDeadLetterPolicy().isDeadLetterChunkingEnabled());
+        assertFalse(configurationData.getDeadLetterPolicy().isRetryLetterBatchingEnabled());
+        assertFalse(configurationData.getDeadLetterPolicy().isRetryLetterChunkingEnabled());
         assertTrue(configurationData.isRetryEnable());
         assertFalse(configurationData.isAutoUpdatePartitions());
         assertEquals(configurationData.getAutoUpdatePartitionsIntervalSeconds(), 2);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
@@ -368,10 +368,15 @@ public class ConsumerBuilderImplTest {
                 .retryLetterChunkingEnabled(true)
                 .build());
         verify(consumerBuilder.getConf()).setDeadLetterPolicy(notNull());
-        assertFalse(consumerBuilder.getConf().getDeadLetterPolicy().isDeadLetterBatchingEnabled());
-        assertFalse(consumerBuilder.getConf().getDeadLetterPolicy().isDeadLetterChunkingEnabled());
-        assertTrue(consumerBuilder.getConf().getDeadLetterPolicy().isRetryLetterBatchingEnabled());
-        assertTrue(consumerBuilder.getConf().getDeadLetterPolicy().isRetryLetterChunkingEnabled());
+        DeadLetterPolicy policy = consumerBuilder.getConf().getDeadLetterPolicy();
+        assertThat(policy.getRetryLetterTopic()).isEqualTo("new-retry");
+        assertThat(policy.getInitialSubscriptionName()).isEqualTo("new-dlq-sub");
+        assertThat(policy.getDeadLetterTopic()).isEqualTo("new-dlq");
+        assertThat(policy.getMaxRedeliverCount()).isEqualTo(2);
+        assertFalse(policy.isDeadLetterBatchingEnabled());
+        assertFalse(policy.isDeadLetterChunkingEnabled());
+        assertTrue(policy.isRetryLetterBatchingEnabled());
+        assertTrue(policy.isRetryLetterChunkingEnabled());
     }
 
     @Test


### PR DESCRIPTION
Fixes #20934 

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
We encountered an issue when chunked messages had to be retried, like
```
org.apache.pulsar.client.api.PulsarClientException$InvalidMessageException: The producer mdl-pulsar-0-12 of the topic part-v1 sends a message with 7094331 bytes that exceeds 5242880 bytes
```
because retry letter and dead letter producers never enable chunking. Our chunked messages may be very large, so simply increasing the maximum is probably not a good option.

This change allows the client to set if they want chunking and batching for these produces. The properties are separated in retry letter and dead letter, since currently the retry letter disables batching while the dead letter enables it implicitly. (So, we did not want a single pair of new properties to always set them to the same value.)

### Modifications

<!-- Describe the modifications you've done. -->

Edited the DeadLetterPolicy to add these new fields, and the ConsumerImpl to pick them up in the consumer and when creating the producers.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
  - Added unit test for setting the new fields, including one checking the defaults

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/rindavis/pulsar/pull/1